### PR TITLE
Fix Markdown in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#Steam Big Picture: Grub theme
+# Steam Big Picture: Grub theme
 
-###Latest Screenshot
+### Latest Screenshot
 
 ![ScreenShot](http://i.imgur.com/yQCOjnR.png)
 
@@ -18,7 +18,7 @@ vbeinfo
 
 The outputs may be different. So after you find out your supported resolutions, download the one that matches your highest supported resolution (or the next one below it). Now to install it, just extract the tar.gz and run the `install.sh` script with root in a terminal. It'll ask you a few questions then install everything in its proper location.
 
-###Requirements:
+### Requirements:
 
 You'll need to install the mscorefonts package and the imagemagick package. On Ubuntu the command is
 
@@ -26,11 +26,11 @@ You'll need to install the mscorefonts package and the imagemagick package. On U
 sudo apt-get install ttf-mscorefonts-installer imagemagick
 ```
 
-###Known Issues:
+### Known Issues:
 
 The `UserName.png` image needs to be converted to RGB in Gimp after installation. The image that you have to edit will be located in `/boot/grub/themes/SteamBP` in Ubuntu. Other distros place this directory somewhere else. I'm trying to figure out why ImageMagick keeps it as Grayscale.
 
-###FAQ:
+### FAQ:
 
 1.  **Why don't you make widescreen versions?**
 
@@ -61,7 +61,7 @@ The `UserName.png` image needs to be converted to RGB in Gimp after installation
 
     Sadly, no. Grub 1 only has support for background images.
 
-###Steam Big Picture Grub Theme TODO list
+### Steam Big Picture Grub Theme TODO list
 
 - ~~Move Progress bar to above buttons, but centered. Remove border and glow, but give grey background. Gradient on fill as well.~~
 
@@ -75,30 +75,30 @@ The `UserName.png` image needs to be converted to RGB in Gimp after installation
 
 - ~~Add bokeh dots to background~~
 
-####One more thing
+#### One more thing
 
 You might noticed the GetProfileImage.sh.x and GetProfileImage.sh. The one with the .x extension is just the .sh file "compiled" with shc. The only thing different from them is that the .x file has an API key written into it.
 
-###Screenshots:
+### Screenshots:
 
 **Old Version**
 ![ScreenShot](http://i.imgur.com/T4pbHXT.png)
 
 **New Version**
 
-###1600x1200  OLD (Static Placement Version)
+### 1600x1200  OLD (Static Placement Version)
 ![ScreenShot](http://i.imgur.com/RbZttjy.png)
 
-###1600x1200 NEW (Relative Placement Version)
+### 1600x1200 NEW (Relative Placement Version)
 ![ScreenShot](http://i.imgur.com/USD0JJP.png)
 
-###1024x768
+### 1024x768
 ![ScreenShot](http://i.imgur.com/bMxCQ4E.png)
 
-###800x600
+### 800x600
 ![ScreenShot](http://i.imgur.com/HxX2EsO.png)
 
-###640x480 - NOT RECOMMENDED!!
+### 640x480 - NOT RECOMMENDED!!
 ![ScreenShot](http://i.imgur.com/l5aT9fE.png)
 
 


### PR DESCRIPTION
GitHub's Markdown interpreter was changed to strictly enforce the GFM spec, which requires a delimiting space in header Markdown. This has caused some Markdown to no longer display as originally intended.

More information:
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
https://github.com/github/markup/issues/1013